### PR TITLE
feat(SSOJira): #COE-6 added attributes for specifics groups

### DIFF
--- a/auth/src/main/java/org/entcore/auth/services/impl/SSOJira.java
+++ b/auth/src/main/java/org/entcore/auth/services/impl/SSOJira.java
@@ -7,6 +7,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.neo4j.Neo4jResult;
+import org.entcore.common.user.UserUtils;
 import org.opensaml.saml2.core.Assertion;
 
 public class SSOJira extends AbstractSSOProvider {
@@ -32,7 +33,15 @@ public class SSOJira extends AbstractSSOProvider {
             addingGroups(user, "structures", result);
             addingGroups(user, "academies", result);
 
-            handler.handle(new Either.Right<>(result));
+            UserUtils.getUserInfos(eb, userId, userInfo -> {
+                String userType = userInfo.getType();
+                if (userType != null && (userInfo.isADML())) {
+                    result.add(new JsonObject().put("group", "jira-administrateur-ent"));
+                } else if (userType != null && (userType.equals("Teacher") || userType.equals("Personnel"))) {
+                    result.add(new JsonObject().put("group", "jira-personnel-ent"));
+                }
+                handler.handle(new Either.Right<>(result));
+            });
         }));
     }
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue.

Added attribute to SSOJira authentication :
- if the user is a "Teacher" or "Personnel", "jira-personnel-ent" group will be added to the response.
- if the user is an "ADML", "jira-administrateur-ent" group will be added to the response.

## Fixes

(Enter here Jira or Redmine ticket(s) links)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [x] auth
- [ ] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

1. Describe here the tests you performed
2. Step by step
3. With expected results

You need to test the response with a "Teacher" user, a "Personnel" user and an "ADML" user
- If the user is a "Teacher" or "Personnel" you will see <cas:jira-personnel-ent></cas:jira-personnel-ent>
- If the user is an "ADML" you will see <cas:jira-administrateur-ent></cas:jira-administrateur-ent>

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ ] All done ! :smiley: