### PR TITLE
feat(cas): #DCN-315 adapted from smartschool's CAS response

### DIFF
--- a/cas/src/main/java/org/entcore/cas/services/SmartSchoolRegisteredService.java
+++ b/cas/src/main/java/org/entcore/cas/services/SmartSchoolRegisteredService.java
@@ -17,6 +17,7 @@ import org.w3c.dom.Element;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 
@@ -26,7 +27,10 @@ public class SmartSchoolRegisteredService extends AbstractCas20ExtensionRegister
         ADMIN,
         CHECKER,
         EDITOR,
-        READER
+        READER,
+        ADMINDF,
+        USERDF,
+        PARTNRINDUS
     }
 
     private static final Logger log = LoggerFactory.getLogger(SmartSchoolRegisteredService.class);
@@ -39,6 +43,7 @@ public class SmartSchoolRegisteredService extends AbstractCas20ExtensionRegister
     private static final String STRUCTURE = "structure";
     private static final String RIGHT = "right";
     private static final String ACTIVE_STRUCTURE = "active_structure";
+    private static final String DIGITALE_FACTORY_STRUCTURE_NAME = "Digitale Factory";
 
     private static final List<String> CHECKER_FUNCTIONS = Arrays.asList("gestionnaireressources", "gestionnaireformation", "offcomecole");
     private static final List<String> EDITOR_FUNCTIONS = Arrays.asList("enseignantinstructeur", "experttice", "encadrementapprenant");
@@ -47,15 +52,17 @@ public class SmartSchoolRegisteredService extends AbstractCas20ExtensionRegister
     protected void prepareUserCas20(User user, String userId, String service, JsonObject data, Document doc, List<Element> additionnalAttributes) {
         try {
             JsonArray userFunctions = data.getJsonArray("functions", new JsonArray());
+            JsonArray structureNodes = data.getJsonArray("structureNodes", new JsonArray());
+            JsonArray userProfiles = data.getJsonArray("profiles", new JsonArray());
 
             user.setUser(data.getString("id"));
             Element rootElement = createElement(EA_ATTRIBUTES, doc);
             rootElement.appendChild(createTextElement(FIRSTNAME, data.getString(FIRSTNAME, ""), doc));
             rootElement.appendChild(createTextElement(LASTNAME, data.getString(LASTNAME, ""), doc));
             rootElement.appendChild(createTextElement(EMAIL, data.getString(EMAIL, ""), doc));
-            rootElement.appendChild(createTextElement(RIGHT, getRight(userFunctions), doc));
+            rootElement.appendChild(createTextElement(RIGHT, getRight(userFunctions, structureNodes, userProfiles), doc));
             rootElement.appendChild(createTextElement(ACTIVE_STRUCTURE, data.getJsonArray("structures", new JsonArray()).getString(0), doc));
-            addStructures(data.getJsonArray("structureNodes", new JsonArray()), doc, rootElement);
+            addStructures(structureNodes, doc, rootElement);
             additionnalAttributes.add(rootElement);
         } catch (Exception e) {
             log.error("Failed to transform user for SmartSchool CAS response", e);
@@ -69,9 +76,28 @@ public class SmartSchoolRegisteredService extends AbstractCas20ExtensionRegister
         }
     }
 
-    private String getRight(JsonArray functions) {
+    private String getRight(JsonArray functions, JsonArray structureNodes, JsonArray userProfiles) {
         if (functions.contains("SuperAdmin")) {
             return RIGHTS.ADMIN.toString();
+        }
+
+        Optional<JsonObject> digitaleFactoryStructure = structureNodes.stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
+                .filter(structureNode -> DIGITALE_FACTORY_STRUCTURE_NAME.equals(structureNode.getString("name")))
+                .findFirst();
+
+        if (digitaleFactoryStructure.isPresent()) {
+            if (functions.contains("AdminLocal")) {
+                return RIGHTS.ADMINDF.toString();
+            }
+            if (userProfiles.contains("Guest")) {
+                if (functions.contains("partenaireministere")) {
+                    return RIGHTS.USERDF.toString();
+                } else {
+                    return RIGHTS.PARTNRINDUS.toString();
+                }
+            }
         }
 
         List<String> userFunctions = functions.getList();


### PR DESCRIPTION
# Description

We have 4 different user groups on Computer 3 for which we must associate these Drupal roles:

Functional Administrator
Industrial Partner
DF user
=> All the other roles already present in smartschool are associated with specific rights (see table on confluence)

We must adapt the CAS smartschool response to export the Drupal role according to the profile and functions of the user.

## Fixes

[DCN-315](https://jira.support-ent.fr/browse/DCN-315)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

## Which packages changed?

Please check the name of the package you changed

- [ ] admin
- [ ] app-registry
- [ ] archive
- [ ] auth
- [x] cas
- [ ] common
- [ ] communication
- [ ] conversation
- [ ] directory
- [ ] feeder
- [ ] infra
- [ ] portal
- [ ] session
- [ ] test
- [ ] tests
- [ ] timeline
- [ ] workspace

## Tests

Create a structure with the name "Digitale Factory"
Create a function with the name "ministrypartner"
Create the following users in the structure:
- User 1: with the local admin function
- User 2: invite with the ministrypartner function
- User 3: invite

Call the SmartSchool case for each user.
In the case response, we have:
- User 1: <cas:right>ADMINDF</cas:right>
- User 2: <cas:right>USERDF</cas:right>
- User 3: <cas:right>PARTNRINDUS</cas:right>

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: